### PR TITLE
fixes issue #214

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -411,10 +411,11 @@
           <div class="col-md-06">
             <div class="form-group">
               <label class="heading" style="text-align:center;">Upload Wallpaper</label>
-              <label id="browse" class="btn btn-secondary mx-auto btn-block btn-secondary">
-                <span  style="white-space: pre-wrap;" data-toggle="tooltip" title=" REC size (1920X1080) or (1280X720)">Browse</span>
-                <input name="file" class="file form-control" title="Default Wallpaper Image" style="display: none;" onchange="$(this).prev('span').text($(this).val()!=''?$(this).val():'Browse')"
-                  required="" type="file">
+              <label id="browse" class="btn btn-primary btn-block mx-auto" style="height:35px; width:360px;">
+                <span  style="white-space:pre-wrap;" data-toggle="tooltip" title=" REC size (1920X1080) or (1280X720)">Browse</span>
+                <input name="file" class="file form-control" title="Default Wallpaper Image"
+                style="display: none;" onchange="$(this).prev('span').text($(this).val()!=''?$(this).val():'Browse')"
+                required="" type="file" />
               </label>
               <span><p id="scroll2">This will be the default background image of the desktop</p></span>
               <img id="file-upload">


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] There is a corresponding issue for this pull request.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [ ] The unit tests pass locally with my changes (provide a screenshot or link for test) <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Initially the browse was not looking like a button and only when we hovered over the browse section it looked like a button. This was because btn-secondary was included in the class of the label. btn-secondary was not working and thus I changed it to btn-primary and it is working fine now. Along with that I indented the label section correctly and also made sure that was no class was repeated twice. btn-secondary was included as a class twice and that is not a good coding practise as it causes confusions.

Before:
![issueofbutton](https://user-images.githubusercontent.com/25319565/46168208-6f7afb80-c2b5-11e8-818f-49bd3debedbe.png)

After:
![browsebuttonworking](https://user-images.githubusercontent.com/25319565/46168226-79046380-c2b5-11e8-9bee-3700bed71fbd.png)

#### Changes proposed in this pull request:

-The browse is looking like a button now

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #214 
