### PR TITLE
fixes #281 (reduces spaces between the 2 browse buttons and introduce…

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -169,6 +169,15 @@ h3.custom-navtitle {
   white-space: pre-wrap;
 }
 
+#browse1 {
+  height:35px;
+  width:360px;
+}
+
+#browse1 > span {
+  white-space: pre-wrap;
+}
+
 #deployment {
   position: absolute;
   text-align: center;
@@ -337,10 +346,10 @@ border-radius: 50%;
 #long {
   width: 100%;
 }
-#scroll-to.active , #scroll1.active  , #scroll2.active{
+#scroll-to.active , #scroll1.active  , #scroll2.active, #scroll3.active{
   display: inline;
 }
-#scroll-to, #scroll1, #scroll2{
+#scroll-to, #scroll1, #scroll2, #scroll3{
   display: none;
 
 }
@@ -387,4 +396,14 @@ font-family: FontAwesome;
 .label-big-check input[type="checkbox"]:checked + .check-title:before {
   content: "\f14a";
   color: #333;
+}
+
+
+.reducespace1{
+   margin-top:-17px;
+}
+
+
+.reducespace2{
+   margin-top:-30px;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -468,7 +468,7 @@
           </div>
 
           <div class="col-md-06">
-            <div class="form-group">
+            <div class="form-group reducespace2">
               <label class="heading" id="upload">Upload Desktop Wallpaper</label>
               <label id="browse" class="btn btn-primary btn-block mx-auto">
                 <span data-toggle="tooltip" title=" REC size (1920X1080) or (1280X720)">Browse</span>
@@ -480,17 +480,20 @@
               </span>
               <img id="file-upload">
             </div>
-            <div class="form-group">
+            <div class="form-group reducespace1">
                 <label class="heading" id="upload">Upload Desktop files (archive) </label>
-                <label id="browse" class="btn btn-primary btn-block mx-auto">
+                <label id="browse1" class="btn btn-primary btn-block mx-auto">
                   <span data-toggle="tooltip" title="Size less than 4 Mb">Browse</span>
-                  <input type="file" name="myFiles" id="zip" accept=".zip, .gz" class="file form-control" title="Custom Files For Desktop" required=""/>
+                  <input type="file" name="myFiles" id="zip" accept=".zip, .gz" class="file form-control" title="Custom Files For Desktop"
+                  required=""/>
                 </label>
-                </div>
+                <span>
+                  <p id="scroll3">These custom files will be kept in your Desktop</p>
+                </span>
+                <img src="" id="preview">
+            </div>
           </div>
-          <div class="col-md-06">
-            <img src="" id="preview">
-          </div>
+
           <div class="form-group">
             <input class="btn btn-info mx-auto file-upload" id="file-upload" value="Build" required="" type="submit" />
           </div>
@@ -547,6 +550,15 @@
       browse.addEventListener('mouseout', function () {
         $('#scroll2').removeClass('active');
       });
+
+      var browse1 = document.getElementById('browse1');
+      browse1.addEventListener('mouseenter', function () {
+        $('#scroll3').addClass('active');
+      });
+      browse1.addEventListener('mouseout', function () {
+        $('#scroll3').removeClass('active');
+      });
+
 
       var zip = document.getElementById('zip');
 


### PR DESCRIPTION

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] There is a corresponding issue for this pull request.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [ ] The unit tests pass locally with my changes (provide a screenshot or link for test) <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Reduces the space between the browse buttons and also introduces the scroll on hover over the second browse button.

Space reduced between the 2 browse buttons and also between the 2nd table and the 1st browse button
![spacereducedbetweenbutton](https://user-images.githubusercontent.com/25319565/46981836-a5164600-d0f7-11e8-84fa-de6edb77624c.png)
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #281 
