### PR TITLE
Browser Home Page accepts wider variety of URLs

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -29,7 +29,7 @@
             <label class="heading" for="event_url">Browser Home Page </label>
             <div class="input-group margin-bottom-sm">
               <span class="input-group-addon"><i class="fa fa-window-maximize fa-fw"></i></span>
-              <input pattern="https?://.+" class="form-control" placeholder="Enter link" name="event_url" data-toggle="tooltip" title="only url is allowed"
+              <input pattern="^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$" class="form-control" placeholder="Enter link" name="event_url" data-toggle="tooltip" title="only url is allowed"
                  type="url"></div>
             <p class="hidden-text">Default home page of the browser</p>
           </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -38,7 +38,7 @@
             <label class="heading" for="search_engine">Default Search Engine</label>
             <div class="input-group margin-bottom-sm">
               <span class="input-group-addon"><i class="fa fa-search fa-fw"></i></span>
-              <input pattern="https?://.+" class="form-control" placeholder="Enter link" name="search_engine" data-toggle="tooltip" title="only url is allowed"
+              <input pattern="^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$" class="form-control" placeholder="Enter link" name="search_engine" data-toggle="tooltip" title="only url is allowed"
                  type="url"></div>
             <p class="hidden-text">Default search engine of the browser</p>
           </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -30,7 +30,7 @@
             <div class="input-group margin-bottom-sm">
               <span class="input-group-addon"><i class="fa fa-window-maximize fa-fw"></i></span>
               <input pattern="^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$" class="form-control" placeholder="Enter link" name="event_url" data-toggle="tooltip" title="only url is allowed"
-                 type="url"></div>
+                 type="text"></div>
             <p class="hidden-text">Default home page of the browser</p>
           </div>
           <br>
@@ -39,7 +39,7 @@
             <div class="input-group margin-bottom-sm">
               <span class="input-group-addon"><i class="fa fa-search fa-fw"></i></span>
               <input pattern="^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$" class="form-control" placeholder="Enter link" name="search_engine" data-toggle="tooltip" title="only url is allowed"
-                 type="url"></div>
+                 type="text"></div>
             <p class="hidden-text">Default search engine of the browser</p>
           </div>
           <br>


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] There is a corresponding issue for this pull request.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes (provide a screenshot or link for test) <!-- use `nosetests tests/unittests` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Solves issue #331 
Browser Home page input field now accepts urls with or without https
As @imahumanrcw pointed out and @meets2tarun @sarnava1 seemed to agree that people normally enter 'www.google.com' instead of 'https://www.google.com/' (just an example) so the website must take that into account people entering the former type of url also.

#### Changes proposed in this pull request:

- Updated Regular Expression Value in the pattern attribute.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #331 

[Preview](https://shrouded-atoll-72279.herokuapp.com/)
