### PR TITLE
Removed redundant code from the my_token readme file - (Solves - #377)

### DIFF
--- a/docs/installation/my_token.md
+++ b/docs/installation/my_token.md
@@ -15,23 +15,6 @@ This file specifies on which repo to trigger build on and which branch to use. I
 
 > **Note:** For your own development be sure to change these tokens.
 
-
-## [script.sh](/script.sh)
-
-Change release link from
-```
-echo "https://github.com/fossasia/meilix/releases/download/${TRAVIS_TAG}/meilix-xenial-`date +%Y%m%d`-i386.iso"
-```
-to
-```
-echo "https://github.com/<username>/meilix/releases/download/${TRAVIS_TAG}/meilix-xenial-`date +%Y%m%d`-i386.iso"
-```
-
-**<username** is your user/organization name where you have cloned meilix to.
-
-Your iso will be released to your fork of meilix.
-
-
 ## Generate travis keys
 
 To trigger builds on travis you need Travis API key. In `script.sh` we use the API key to trigger the build.


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] There is a corresponding issue for this pull request.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [ ] The unit tests pass locally with my changes (provide a screenshot or link for test) <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
This removes redundant command from the my_token readme file because this code was not present 
in the script shell file
`echo "https://github.com/fossasia/meilix/releases/download/${TRAVIS_TAG}/meilix-xenial-`date +%Y%m%d`-i386.iso"`
and
`echo "https://github.com/<username>/meilix/releases/download/${TRAVIS_TAG}/meilix-xenial-`date +%Y%m%d`-i386.iso"` 
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #377 