### PR TITLE
Send generator-package array as json-array to the build server - (Solves- #397) 

### DIFF
--- a/app.py
+++ b/app.py
@@ -96,7 +96,7 @@ def index():
         for name, value in request.form.items():
           if name.startswith("GENERATOR_"):
             variables[name] = value
-        features = json.dumps(variables, ensure_ascii=False)
+        packages = json.dumps(variables, ensure_ascii=False) # Dumping the generator-packages into a JSON array
         wallpaper = request.files["desktop-wallpaper"]
         upload_wallpaper(wallpaper)
         logo = request.files["desktop-logo"]
@@ -108,7 +108,7 @@ def index():
             TRAVIS_TAG = urlify(TRAVIS_TAG)  # this will fix url issue
             os.environ["TRAVIS_TAG"] = TRAVIS_TAG
             os.environ["event_url"] = event_url
-            os.environ["features"] = features
+            os.environ["packages"] = packages
             with open('travis_script_1.sh', 'rb') as f:
                 os.environ["TRAVIS_SCRIPT"] = str(base64.b64encode(f.read()))[1:]
             return redirect(url_for('output'))
@@ -119,7 +119,7 @@ def index():
 def output():
     if flag:
         if os.environ['TRAVIS_TAG']:  # if TRAVIS_TAG have value it will proceed
-            build.send_trigger_request(os.environ['email'], os.environ['TRAVIS_TAG'], os.environ['event_url'],os.environ['TRAVIS_SCRIPT'], os.environ['features'])
+            build.send_trigger_request(os.environ['email'], os.environ['TRAVIS_TAG'], os.environ['event_url'],os.environ['TRAVIS_SCRIPT'], os.environ['packages'])
             print ('/build called')
             return render_template('build.html')
         else:

--- a/app.py
+++ b/app.py
@@ -96,7 +96,7 @@ def index():
         for name, value in request.form.items():
           if name.startswith("GENERATOR_"):
             variables[name] = value
-        packages = json.dumps(variables, ensure_ascii=False) # Dumping the generator-packages into a JSON array
+        recipe = json.dumps(variables, ensure_ascii=False) # Dumping the generator-packages into a JSON array
         wallpaper = request.files["desktop-wallpaper"]
         upload_wallpaper(wallpaper)
         logo = request.files["desktop-logo"]
@@ -108,7 +108,7 @@ def index():
             TRAVIS_TAG = urlify(TRAVIS_TAG)  # this will fix url issue
             os.environ["TRAVIS_TAG"] = TRAVIS_TAG
             os.environ["event_url"] = event_url
-            os.environ["packages"] = packages
+            os.environ["recipe"] = recipe
             with open('travis_script_1.sh', 'rb') as f:
                 os.environ["TRAVIS_SCRIPT"] = str(base64.b64encode(f.read()))[1:]
             return redirect(url_for('output'))
@@ -119,7 +119,7 @@ def index():
 def output():
     if flag:
         if os.environ['TRAVIS_TAG']:  # if TRAVIS_TAG have value it will proceed
-            build.send_trigger_request(os.environ['email'], os.environ['TRAVIS_TAG'], os.environ['event_url'],os.environ['TRAVIS_SCRIPT'], os.environ['packages'])
+            build.send_trigger_request(os.environ['email'], os.environ['TRAVIS_TAG'], os.environ['event_url'],os.environ['TRAVIS_SCRIPT'], os.environ['recipe'])
             print ('/build called')
             return render_template('build.html')
         else:

--- a/app.py
+++ b/app.py
@@ -119,7 +119,7 @@ def index():
 def output():
     if flag:
         if os.environ['TRAVIS_TAG']:  # if TRAVIS_TAG have value it will proceed
-            build.send_trigger_request(os.environ['email'], os.environ['TRAVIS_TAG'], os.environ['event_url'],os.environ['TRAVIS_SCRIPT'])
+            build.send_trigger_request(os.environ['email'], os.environ['TRAVIS_TAG'], os.environ['event_url'],os.environ['TRAVIS_SCRIPT'], os.environ['features'])
             print ('/build called')
             return render_template('build.html')
         else:

--- a/build.py
+++ b/build.py
@@ -3,7 +3,7 @@ import json
 import os
 import requests
 
-def send_trigger_request(email, TRAVIS_TAG, event_url, TRAVIS_SCRIPT, packages):
+def send_trigger_request(email, TRAVIS_TAG, event_url, TRAVIS_SCRIPT, recipe):
     USER = 'fossasia'
     PROJECT = 'meilix'
     BRANCH = 'master'
@@ -17,7 +17,7 @@ def send_trigger_request(email, TRAVIS_TAG, event_url, TRAVIS_SCRIPT, packages):
     request['config']['env']['TRAVIS_TAG'] = TRAVIS_TAG
     request['config']['env']['event_url'] = event_url
     request['config']['env']['TRAVIS_SCRIPT'] = TRAVIS_SCRIPT
-    request['config']['env']['packages'] = packages
+    request['config']['env']['recipe'] = recipe
     request_body['request'] = request
     request_body = json.dumps(request_body)
     headers = { "Content-Type": "application/json", "Accept": "application/json", "Travis-API-Version": "3", "Authorization": "token {}".format(os.environ.get('KEY', None))}

--- a/build.py
+++ b/build.py
@@ -3,12 +3,10 @@ import json
 import os
 import requests
 
-def send_trigger_request(email, TRAVIS_TAG, event_url, TRAVIS_SCRIPT, features):
+def send_trigger_request(email, TRAVIS_TAG, event_url, TRAVIS_SCRIPT, packages):
     USER = 'fossasia'
     PROJECT = 'meilix'
     BRANCH = 'master'
-    features = json.dumps(features)
-    packages = str(features)
     travis_api_url = 'https://api.travis-ci.org/repo/{}%2F{}/requests'.format(USER, PROJECT)
     request_body = {}
     request = {}
@@ -19,6 +17,7 @@ def send_trigger_request(email, TRAVIS_TAG, event_url, TRAVIS_SCRIPT, features):
     request['config']['env']['TRAVIS_TAG'] = TRAVIS_TAG
     request['config']['env']['event_url'] = event_url
     request['config']['env']['TRAVIS_SCRIPT'] = TRAVIS_SCRIPT
+    request['config']['env']['packages'] = packages
     request_body['request'] = request
     request_body = json.dumps(request_body)
     headers = { "Content-Type": "application/json", "Accept": "application/json", "Travis-API-Version": "3", "Authorization": "token {}".format(os.environ.get('KEY', None))}

--- a/build.py
+++ b/build.py
@@ -3,10 +3,12 @@ import json
 import os
 import requests
 
-def send_trigger_request(email, TRAVIS_TAG, event_url, TRAVIS_SCRIPT):
+def send_trigger_request(email, TRAVIS_TAG, event_url, TRAVIS_SCRIPT, features):
     USER = 'fossasia'
     PROJECT = 'meilix'
     BRANCH = 'master'
+    features = json.dumps(features)
+    packages = str(features)
     travis_api_url = 'https://api.travis-ci.org/repo/{}%2F{}/requests'.format(USER, PROJECT)
     request_body = {}
     request = {}


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] There is a corresponding issue for this pull request.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [ ] The unit tests pass locally with my changes (provide a screenshot or link for test) <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
This sends the generator-package array from the webapp to the build server sending it as a json array
This array can be further used in the build server for installing packages

#### Changes proposed in this pull request:

- Dumping the package array into a json array
- Sending the json array to the build server with the trigger request
-

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #397 
