### PR TITLE
Set default value of processor to amd64 to avoid meilix build failure - (Solves- #417)

### DIFF
--- a/app.py
+++ b/app.py
@@ -94,7 +94,7 @@ def index():
         event_url = request.form['event_url']
         variables = {}
         features = {}
-        processor = ""
+        processor = "amd64" # This will fixe build failure when 32bit is not chosen
         for name, value in request.form.items():
             if name == "processor":
                 processor = value


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] There is a corresponding issue for this pull request.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [ ] The unit tests pass locally with my changes (provide a screenshot or link for test) <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
This adds default value to the variable processor so that we can have error free meilix builds

#### Changes proposed in this pull request:

- Setting the default value of processor to amd64
-
-

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #417 
