### PR TITLE
customising Travis API URL using environment variables

### DIFF
--- a/build.py
+++ b/build.py
@@ -4,9 +4,10 @@ import os
 import requests
 
 def send_trigger_request(email, TRAVIS_TAG, event_url, TRAVIS_SCRIPT, recipe, processor, feature):
-    USER = 'fossasia'
-    PROJECT = 'meilix'
-    BRANCH = 'master'
+    # Params for Travis API
+    USER = os.environ.get('USER','fossasia')
+    PROJECT = os.environ.get('PROJECT', 'meilix')
+    BRANCH = os.environ.get('BRANCH', 'master')
     softwares = json.dumps(recipe) # This solves `unbound variable`(ISSUE #405)
     feature = json.dumps(feature)
     travis_api_url = 'https://api.travis-ci.org/repo/{}%2F{}/requests'.format(USER, PROJECT)


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] There is a corresponding issue for this pull request.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [ ] The unit tests pass locally with my changes (provide a screenshot or link for test) <!-- use `nosetests tests/unittests` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Changing Travis API request to point to your own fork of Meilix requires a change in the USER variable in build.py.

#### Changes proposed in this pull request:
- The user now needs to set environment variables - USER, PROJECT and BRANCH according to their fork of meilix(https://github.com/alok760/meilix). The default values are fossasia, meilix and master respectively.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #422
